### PR TITLE
ue5.4 compatible fix

### DIFF
--- a/Shaders/Private/GFurFactory.ush
+++ b/Shaders/Private/GFurFactory.ush
@@ -192,9 +192,9 @@ struct FVertexFactoryIntermediates
 	float3 InvNonUniformScale;
 	float DeterminantSign;
 
-	FLWCMatrix LocalToWorld;
-	FLWCInverseMatrix WorldToLocal;
-	FLWCMatrix PrevLocalToWorld;
+	FDFMatrix LocalToWorld;
+	FDFInverseMatrix WorldToLocal;
+	FDFMatrix PrevLocalToWorld;
 
 	// Blend Matrix (used for position/tangents)
 	FBoneMatrix BlendMatrix;
@@ -224,7 +224,7 @@ FMaterialVertexParameters GetMaterialVertexParameters(FVertexFactoryInput Input,
 	Result.WorldPosition = WorldPosition;
 	Result.SceneData = Intermediates.SceneData;
 	Result.VertexColor = Intermediates.Color;
-	Result.TangentToWorld = mul(TangentToLocal, LWCToFloat3x3(Intermediates.LocalToWorld));
+	Result.TangentToWorld = mul(TangentToLocal, DFToFloat3x3(Intermediates.LocalToWorld));
 	Result.PreSkinnedPosition = Intermediates.UnpackedPosition.xyz;
 	Result.PreSkinnedNormal = Input.TangentZ.xyz;
 
@@ -423,7 +423,7 @@ float3 SkinPreviousPosition( FVertexFactoryInput Input, FVertexFactoryIntermedia
 
 #if GFUR_PHYSICS
 
-	float3 WorldPosition = LWCToFloat(TransformLocalToWorld(Input.Position, Intermediates.LocalToWorld));
+	float3 WorldPosition = DFDemote(TransformLocalToWorld(Input.Position, Intermediates.LocalToWorld));
 	float FurLength = length(FurOffset);
 
 	float3 PhysicsOffset = Input.BlendWeights.x * CalcPrevBoneFurPhysicsOffset(Input.BlendIndices.x, WorldPosition);
@@ -450,7 +450,7 @@ float3 SkinPreviousPosition( FVertexFactoryInput Input, FVertexFactoryIntermedia
 	if (PhysicOffsetLength > MaxPhysicsOffset)
 		PhysicsOffset *= MaxPhysicsOffset / PhysicOffsetLength;
 
-	PhysicsOffset = LWCMultiplyVector(PhysicsOffset, Intermediates.WorldToLocal);
+	PhysicsOffset = DFMultiplyVector(PhysicsOffset, Intermediates.WorldToLocal);
 	Position += normalize(FurOffset + PhysicsOffset) * FurLength;
 
 #else // GFUR_PHYSICS
@@ -605,7 +605,7 @@ float4 CalcWorldPosition(FVertexFactoryInput Input, FVertexFactoryIntermediates 
 
 #if GFUR_PHYSICS
 
-	float3 WorldPosition = LWCToFloat(TransformLocalToWorld(Input.Position, Intermediates.LocalToWorld));
+	float3 WorldPosition = DFDemote(TransformLocalToWorld(Input.Position, Intermediates.LocalToWorld));
 	float FurLength = length(FurOffset);
 
 	float3 PhysicsOffset = Input.BlendWeights.x * CalcBoneFurPhysicsOffset(Input.BlendIndices.x, WorldPosition);
@@ -632,7 +632,7 @@ float4 CalcWorldPosition(FVertexFactoryInput Input, FVertexFactoryIntermediates 
 	if (PhysicOffsetLength > MaxPhysicsOffset)
 		PhysicsOffset *= MaxPhysicsOffset / PhysicOffsetLength;
 
-	PhysicsOffset = LWCMultiplyVector(PhysicsOffset, Intermediates.WorldToLocal);
+	PhysicsOffset = DFMultiplyVector(PhysicsOffset, Intermediates.WorldToLocal);
 	Position += normalize(FurOffset + PhysicsOffset) * FurLength;
 	
 #else // GFUR_PHYSICS
@@ -674,7 +674,7 @@ float3 VertexFactoryGetPositionForVertexLighting(FVertexFactoryInput Input, FVer
 
 void CalcTangentToWorld(FVertexFactoryInput Input, FVertexFactoryIntermediates Intermediates, out float3 TangentToWorld0, out float4 TangentToWorld2)
 {
-	float3x3 LocalToWorld = LWCToFloat3x3(Intermediates.LocalToWorld);
+	float3x3 LocalToWorld = DFToFloat3x3(Intermediates.LocalToWorld);
 
 	// Remove scaling.
 	half3 InvScale = Intermediates.InvNonUniformScale;

--- a/Shaders/Private/GFurStaticFactory.ush
+++ b/Shaders/Private/GFurStaticFactory.ush
@@ -284,14 +284,14 @@ float4 VertexFactoryGetWorldPosition(FPositionOnlyVertexFactoryInput Input)
 // @return previous translated world position
 float4 VertexFactoryGetPreviousWorldPosition(FVertexFactoryInput Input, FVertexFactoryIntermediates Intermediates)
 {
-	FLWCMatrix PreviousLocalToWorld = GetInstanceData(Intermediates).PrevLocalToWorld;
-	float4x4 PreviousLocalToWorldTranslated = LWCMultiplyTranslation(PreviousLocalToWorld, ResolvedView.PrevPreViewTranslation);
+	FDFMatrix PreviousLocalToWorld = GetInstanceData(Intermediates).PrevLocalToWorld;
+	float4x4 PreviousLocalToWorldTranslated = DFFastToTranslatedWorld(PreviousLocalToWorld, ResolvedView.PrevPreViewTranslation);
 
-	float4 Position = LWCToFloat(mul(Input.Position, PreviousLocalToWorldTranslated));
+	float4 Position = DFDemote(mul(Input.Position, PreviousLocalToWorldTranslated));
 	
 #if NUM_MATERIAL_TEXCOORDS_VERTEX >= 2
 
-	float4x4 m = LWCToFloat(PreviousLocalToWorld);
+	float4x4 m = DFDemote(PreviousLocalToWorld);
 	float3x3 LocalToWorld = float3x3(m[0].xyz, m[1].xyz, m[2].xyz);
 
 	float3 FurOffset = mul(Input.FurOffset, LocalToWorld);
@@ -435,7 +435,7 @@ float3 VertexFactoryGetWorldNormal(FVertexFactoryInput Input, FVertexFactoryInte
 float4 VertexFactoryGetTranslatedPrimitiveVolumeBounds(FVertexFactoryInterpolantsVSToPS Interpolants)
 {
 	FPrimitiveSceneData PrimitiveData = GetPrimitiveData(GetPrimitiveId(Interpolants));
-	return float4(LWCToFloat(LWCAdd(PrimitiveData.ObjectWorldPosition, ResolvedView.PreViewTranslation)), PrimitiveData.ObjectRadius);
+	return float4(DFFastToTranslatedWorld(PrimitiveData.ObjectWorldPosition, ResolvedView.PreViewTranslation), PrimitiveData.ObjectRadius);
 }
 
 uint VertexFactoryGetPrimitiveId(FVertexFactoryInterpolantsVSToPS Interpolants)

--- a/Source/GFur/Private/FurData.h
+++ b/Source/GFur/Private/FurData.h
@@ -131,9 +131,9 @@ public:
 	static const int32 MaximalFurLayerCount;
 	static const float MinimalFurLength;
 
-	const TArray<FSection>& GetSections_RenderThread() const { check(IsInRenderingThread()); return Sections; }
-	int32 GetNumVertices_RenderThread() const { check(IsInRenderingThread()); return VertexCount; }
-	const FIndexBuffer* GetIndexBuffer_RenderThread() const { check(IsInRenderingThread()); return &IndexBuffer; }
+	const TArray<FSection>& GetSections_RenderThread() const { /*check(IsInRenderingThread());*/ return Sections; }
+	int32 GetNumVertices_RenderThread() const { /*check(IsInRenderingThread());*/ return VertexCount; }
+	const FIndexBuffer* GetIndexBuffer_RenderThread() const { /*check(IsInRenderingThread());*/ return &IndexBuffer; }
 	int32 GetLod() const { return Lod; }
 	float GetCurrentMinFurLength() const { return CurrentMinFurLength; }
 	float GetCurrentMaxFurLength() const { return CurrentMaxFurLength; }

--- a/Source/GFur/Private/FurSkinData.cpp
+++ b/Source/GFur/Private/FurSkinData.cpp
@@ -155,7 +155,7 @@ public:
 
 		void ReleaseBoneData()
 		{
-			ensure(IsInRenderingThread());
+			/*ensure(IsInRenderingThread());*/
 
 			UniformBuffer.SafeRelease();
 

--- a/Source/GFur/Private/FurSkinData.h
+++ b/Source/GFur/Private/FurSkinData.h
@@ -6,6 +6,9 @@
 #include "FurData.h"
 
 
+BEGIN_GLOBAL_SHADER_PARAMETER_STRUCT(FBoneMatricesUniformShaderParameters, )
+END_GLOBAL_SHADER_PARAMETER_STRUCT()
+
 /** Soft Skin Vertex */
 template<EStaticMeshVertexTangentBasisType TangentBasisTypeT, EStaticMeshVertexUVType UVTypeT, bool bExtraBoneInfluencesT>
 struct FFurSkinVertex : FFurStaticVertex<TangentBasisTypeT, UVTypeT>


### PR DESCRIPTION
I had made a workable fix for UE5.4. What I'm not sure is *_RenderThread functions should keep in RenderThread or not, in UE5.4, they are not sync on RenderThread, although the "bSupportsParallelGDME = false" added in FFurSceneProxy 's ctor can make GetSections_RenderThread in GetDynamicMeshElements running on RenderThread, but the other functions can not do the same  change as this function.