### PR TITLE
fix the compilation errors

### DIFF
--- a/Source/GFur/Private/FurSkinData.h
+++ b/Source/GFur/Private/FurSkinData.h
@@ -6,9 +6,6 @@
 #include "FurData.h"
 
 
-BEGIN_GLOBAL_SHADER_PARAMETER_STRUCT(FBoneMatricesUniformShaderParameters, )
-END_GLOBAL_SHADER_PARAMETER_STRUCT()
-
 /** Soft Skin Vertex */
 template<EStaticMeshVertexTangentBasisType TangentBasisTypeT, EStaticMeshVertexUVType UVTypeT, bool bExtraBoneInfluencesT>
 struct FFurSkinVertex : FFurStaticVertex<TangentBasisTypeT, UVTypeT>

--- a/Source/GFurEditor/Private/FurSplineAbcImporterFactory.cpp
+++ b/Source/GFurEditor/Private/FurSplineAbcImporterFactory.cpp
@@ -16,6 +16,7 @@
 #include "Widgets/Input/SComboBox.h"
 #include "Editor/MainFrame/Public/Interfaces/IMainFrameModule.h"
 #include "Widgets/Input/SNumericEntryBox.h"
+#include "Widgets/Layout/SUniformGridPanel.h"
 
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"

--- a/Source/GFurEditor/Private/FurSplinesTypeActions.cpp
+++ b/Source/GFurEditor/Private/FurSplinesTypeActions.cpp
@@ -4,7 +4,7 @@
 #include "GFurEditor.h"
 #include "FurSplines.h"
 
-//#define LOCTEXT_NAMESPACE "AssetTypeActions"
+#define LOCTEXT_NAMESPACE "AssetTypeActions"
 
 FFurSplinesTypeActions::FFurSplinesTypeActions(EAssetTypeCategories::Type InAssetCategory)
 	:MyAssetCategory(InAssetCategory)


### PR DESCRIPTION
Remove the declaration of FBoneMatricesUniformShaderParameters because it had already been fixed in 8ae3421;
fix the other 2 GFurEditor compile errors in UE5.4