### PR TITLE
missing header, compile error

### DIFF
--- a/Source/GFur/Private/FurSkinData.h
+++ b/Source/GFur/Private/FurSkinData.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Runtime/Engine/Classes/Engine/SkeletalMesh.h"
+#include "GPUSkinPublicDefs.h"
 #include "FurData.h"
 
 


### PR DESCRIPTION
The IncludeOrderVersion set to Latest in target.cs will cause this compilation error, add the header file and fix.