### PR TITLE
Unreal Engine 5.5 compilation and shader crash fixes

### DIFF
--- a/GFur.uplugin
+++ b/GFur.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "gim.studio/animalia/gfur",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/c657e6d3d6c9467db3e96c828529841b",
 	"SupportURL": "gfur@gim.studio",
-	"EngineVersion": "5.4.1",
+	"EngineVersion": "5.5.0",
 	"CanContainContent": true,
 	"Installed": true,
 	"Modules": [

--- a/Shaders/Private/GFurFactory.ush
+++ b/Shaders/Private/GFurFactory.ush
@@ -218,7 +218,7 @@ struct FVertexFactoryIntermediates
 };
 
 /** Converts from vertex factory specific input to a FMaterialVertexParameters, which is used by vertex shader material inputs. */
-FMaterialVertexParameters GetMaterialVertexParameters(FVertexFactoryInput Input, FVertexFactoryIntermediates Intermediates, float3 WorldPosition, float3x3 TangentToLocal)
+FMaterialVertexParameters GetMaterialVertexParameters(FVertexFactoryInput Input, FVertexFactoryIntermediates Intermediates, float3 WorldPosition, float3x3 TangentToLocal, bool bIsPreviousFrame = false)
 {
 	FMaterialVertexParameters Result = MakeInitializedMaterialVertexParameters();
 	Result.WorldPosition = WorldPosition;

--- a/Shaders/Private/GFurStaticFactory.ush
+++ b/Shaders/Private/GFurStaticFactory.ush
@@ -111,7 +111,7 @@ half3x3 CalcTangentToWorldNoScale(FVertexFactoryIntermediates Intermediates, in 
 }
 
 /** Converts from vertex factory specific input to a FMaterialVertexParameters, which is used by vertex shader material inputs. */
-FMaterialVertexParameters GetMaterialVertexParameters(FVertexFactoryInput Input, FVertexFactoryIntermediates Intermediates, float3 WorldPosition, half3x3 TangentToLocal)
+FMaterialVertexParameters GetMaterialVertexParameters(FVertexFactoryInput Input, FVertexFactoryIntermediates Intermediates, float3 WorldPosition, half3x3 TangentToLocal, bool bIsPreviousFrame = false)
 {
 	FMaterialVertexParameters Result = MakeInitializedMaterialVertexParameters();
 	Result.SceneData = Intermediates.SceneData;

--- a/Source/GFur/Private/FurSkinData.cpp
+++ b/Source/GFur/Private/FurSkinData.cpp
@@ -1324,7 +1324,7 @@ inline void FFurSkinData::BuildFur(const FSkeletalMeshLODRenderData& LodRenderDa
 			FurSection.NumBones = SourceSection.BoneMap.Num();
 		}
 		check(Idx <= (uint32)Indices.Num());
-		Indices.RemoveAt(Idx, Indices.Num() - Idx, false);
+		Indices.RemoveAt(Idx, Indices.Num() - Idx, EAllowShrinking::No);
 		IndexBuffer.Unlock();
 
 		if (TempSections.Num())

--- a/Source/GFur/Private/FurSplines.cpp
+++ b/Source/GFur/Private/FurSplines.cpp
@@ -92,7 +92,7 @@ void UFurSplines::ConvertToUniformControlPointCount(int32 NumControlPoints)
 		}
 	}
 	check(Idx == Temp.Num());
-	Temp.RemoveAt(Idx, Temp.Num() - Idx, true);
+	Temp.RemoveAt(Idx, Temp.Num() - Idx, EAllowShrinking::Yes);
 	Index.SetNum(0);
 	Count.SetNum(0);
 	Vertices = Temp;

--- a/Source/GFur/Private/FurStaticData.cpp
+++ b/Source/GFur/Private/FurStaticData.cpp
@@ -662,7 +662,7 @@ inline void FFurStaticData::BuildFur(const FStaticMeshLODResources& LodRenderDat
 			FurSection.NumBones = 0;
 		}
 		check(Idx <= (uint32)Indices.Num());
-		Indices.RemoveAt(Idx, Indices.Num() - Idx, false);
+		Indices.RemoveAt(Idx, Indices.Num() - Idx, EAllowShrinking::No);
 
 		if (TempSections.Num())
 		{


### PR DESCRIPTION
- updated TArray< RemoveAt API bool param to EAllowShrinking enum
- updated GFurFactory and GFurStaticFactory.ush to include new optional bool param on GetMaterialVertexParameters
- updated GetDynamicRayTracingInstances to use new API, removing deprecated warning. 
- Updated RayTracingGeometry RHI direct ptr access to use the GetRHI method with the new api.
- Updated .uplugin EngineVersion to 5.5.0 to prevent startup warning